### PR TITLE
Fix broken links.

### DIFF
--- a/references.html
+++ b/references.html
@@ -30,7 +30,7 @@ categories: [ocitao]
     </dt>
     <dd>
       Source code for all examples from the
-      <a target="new window" href="{{site.baseurl}}/product/index.html">
+      <a target="new window" href="{{site.baseurl}}/purchase.html">
         TAO Developer's Guide</a> are available for free.
       For the most recent releases, they are available in the
       source code distribution itself, in the
@@ -50,7 +50,7 @@ categories: [ocitao]
       {{site.baseurl}}/downloads/</a><br />
       OCI's downloads site for TAO.<br />
       Provides access to OCI TAO source code, patch releases,
-      examples, release notes, <a target="new window" href="{{site.baseurl}}/product/index.html">
+      examples, release notes, <a target="new window" href="{{site.baseurl}}/purchase.html">
         TAO Developer's Guide</a> excerpts, Doxygen-generated
       documentation, and other useful resources.
     </dd>
@@ -61,8 +61,8 @@ categories: [ocitao]
       Purchase OCI's TAO products
     </dt>
     <dd>
-      <a target="new window" href="{{site.baseurl}}/purchase/">
-      {{site.baseurl}}/purchase/</a><br />
+      <a target="new window" href="{{site.baseurl}}/purchase.html">
+      {{site.baseurl}}/purchase.html</a><br />
       Purchase OCI's TAO products (e.g., <i><b>TAO Developer's
       Guide</b></i> and pre-built binaries of TAO) on-line.
     </dd>
@@ -73,8 +73,8 @@ categories: [ocitao]
       TAO Frequently Asked Questions (FAQ)
     </dt>
     <dd>
-      <a target="new window" href="{{site.baseurl}}/faq/">
-      {{site.baseurl}}/faq/</a><br />
+      <a target="new window" href="{{site.baseurl}}/support/faq.html">
+      {{site.baseurl}}/support/faq.html</a><br />
       The TAO FAQ, maintained by OCI for the CORBA and TAO community.
     </dd>
 
@@ -96,8 +96,8 @@ categories: [ocitao]
       OCI CORBA and TAO training
     </dt>
     <dd>
-      <a target="new window" href="{{site.baseurl}}/training/index.html">
-      {{site.baseurl}}/training/index.html</a><br />
+      <a target="new window" href="{{site.baseurl}}/support/training.html">
+      {{site.baseurl}}/support/training.html</a><br />
       Information about OCI's training courses for CORBA and TAO.<br />
       Also, see our on-line course catalog and other training information:
       <a target="new window" href="http://www.objectcomputing.com/training">
@@ -305,8 +305,8 @@ categories: [ocitao]
       <i><b>OCI's TAO Developer's Guide</b></i>
     </dt>
     <dd>
-      <a target="new window" href="{{site.baseurl}}/purchase/index.html">
-        {{site.baseurl}}/purchase/index.html</a>
+      <a target="new window" href="{{site.baseurl}}/purchase.html">
+        {{site.baseurl}}/purchase.html</a>
     </dd>
 
     <p>


### PR DESCRIPTION
There are a number of broken links on the References page. This fixes those that point to pages within this site. I'm not addressing broken external links at this time as doing so will require a fair amount of content rewrite that I am not prepared to do now.